### PR TITLE
Add "how to host" document; fixes #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,11 @@ Much of the material for this course was drawn from the following:
 [k-r-main]: http://www.iups.org/media/meeting_minutes/C.pdf
 [learn-c-hard-way-main]: http://c.learncodethehardway.org/book/
 
+## How to Host This Event
+[Tips for Running This Series][hosting-tips]
+
+[hosting-tips]: ./notes/meta/how_to_host.md
+
 ##License
 [MIT License][mit-license]
 

--- a/notes/meta/how_to_host.md
+++ b/notes/meta/how_to_host.md
@@ -1,0 +1,106 @@
+# Hosting The C Programming Study Group
+If you're looking to run a Women Who Code C Programming Study Group where you
+can offer talks and exercises that build skill and understanding over time,
+you've come to the right place.
+
+## Requirements
+To conduct this study group, it's best to have:
+
+C Programming Leads - Leaders who have experience programming C or have studied
+the C Programming Language before, and who are willing to commit to plan and
+facilitate this study group. What to leaders do? Some of the following:
+
+ - Complete the week's readings and exercises ahead of time
+ - Find guest speakers or give a demo themselves of topic for that week
+ - Encourage connection and collaboration between attendees
+ - Answer questions about C Programming
+ - Find hosts for the event
+ - Sent out invitations
+
+## Tools and Resources
+ -  Online invitation ([example from past event][c-meetup-event-example])
+ -  Location: an office space
+ -  Projector
+ -  This curriculum (and links to it in whatever form is easiest)
+ -  White Boards (Optional)
+
+[c-meetup-event-example]: http://www.meetup.com/Women-Who-Code-SF/events/220964373/
+
+## Attendees
+This meetup will be focused on learning the basics of C and supporting
+ongoing C learners. Targeted for programmers who already know at least one
+programming language, are excited about learning C, and would love to better
+understand the inner workings of memory management.
+
+## Online Invitation Sample:
+```
+This meetup will be focused on learning the basics of C and supporting ongoing C
+learners. Targeted for programmers who already know at least one programming
+language, are excited about learning C, and would love to better understand the
+inner workings of memory management.
+
+8-week series curriculum:
+
+Part I - Introduction to the Language
+2/5 - Installation, Compilers, and Hello World
+2/19 - Language Basics, Part 1
+3/5 - Language Basics, Part 2
+3/19 - C-specific Basics
+
+Part II - More Advanced Topics; Project **
+4/2 - Pointers and Standard Libraries
+4/16 - Memory Allocation
+4/30 - Datatypes
+5/14 - Advanced Lab
+
+Please try to attend the early sessions if you're new to the language, as we
+will unfortunately not be repeating material.
+
+Who should take this series?
+* Programmers with skill in one other programming language, like Ruby.
+* Programmers who need to relearn C.
+* Objective-C programmers who want better C skills.
+* Programmers who want to learn more about memory management.
+
+** Curriculum subject to change
+```
+
+## About C Programming
+C is an imperative, compiled language and studying C can expand your
+understanding of procedural programming and direct memory handling.
+
+Is C still relevant? Yes! Because:
+ - Many languages borrow its syntax style
+   -  eg. JavaScript, C++, Go, Rust, Python
+ - Foundational C layer for many languages
+   - eg. Python, Julia, Objective-C, PHP
+ - If you want to be able do anything at the system level, need a C library
+ - Used in several areas of computing
+ - Wearables (and other embedded devices)
+ - Mobile devices
+ - Security
+ - Operating Systems (eg. linux kernel, android os)
+
+The above notes from [slides][daphne-slides-why-learn-c] by @lifeissweetgood
+a.k.a. Daphne Larose.
+
+[daphne-slides-why-learn-c]: https://docs.google.com/presentation/d/18gWp1Lubwot9QB6nsrXT8Ds-0gX8bdqzmHxF8Gs9ZEo/edit?usp=sharing
+
+## Additional Notes
+This event is intended to be exclusively open for people who identify as women
+-- queer and transgender friendly.
+
+We originally scheduled this event bi-weekly, but weekly events would also work
+well.
+
+You can recruit outside speakers to give short presentations related to your
+group's focus topic and also encourage members themselves to present something
+new they've learned or share projects they are working on. Try to vary the level
+of talks from beginner to more intermediate or advanced. Keep the presentation
+short and informal however so the focus of the group is on self-paced study
+time.
+
+During study time, encourage members to speak up and help each other if they get
+stuck. Allow members to study as they wish using the materials of their choice
+or to work on personal projects. Members can either study independently or join
+the small groups to work together as they prefer.


### PR DESCRIPTION
Taking a note from the WWC Algorithms and Interviews Study Group, we are
adding a "How to Host This Event" section similar to the other group's
[wiki intro page][wwc-algo-how-to-host].

This section should help others use this curriculum to start their own
study groups.

[wwc-algo-how-to-host]: https://github.com/WomenWhoCode/Algorithms-InterviewPrep/wiki